### PR TITLE
alternative method

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -6,7 +6,7 @@
 #   MINOR version when you add functionality in a backwards-compatible manner, and
 #   PATCH version when you make backwards-compatible bug fixes.
 #
-# version must always start with "v" like:  v0.1.45-rc 
+# version must always start with "v" like:  v0.1.45-rc
 VERSION=v0.0.5
 # This must match the tags in the github repository
 
@@ -23,7 +23,7 @@ NEEDED_TOOLS="rsync wget 7z cut awk sha256sum gzip tar e2fsck losetup resize2fs 
 # Internet resources
 # Armbian latest image dynamic link is https://dl.armbian.com/orangepiprime/Debian_stretch_next.7z
 # URL for the lsit of all recent version is this: https://dl.armbian.com/orangepiprime/archive/
-ARMBIAN_OPPRIME_DOWNLOAD_URL="https://dl.armbian.com/orangepiprime/archive/Armbian_5.75_Orangepiprime_Debian_stretch_next_4.19.20.7z"
+ARMBIAN_OPPRIME_DOWNLOAD_URL="https://dl.armbian.com/orangepiprime/archive/Armbian_20.02.1_Orangepiprime_stretch_current_5.4.20.7z"
 GO_VERSION="1.11.2"
 GO_ARM64_URL="https://dl.google.com/go/go${GO_VERSION}.linux-arm64.tar.gz"
 GO_FILE=""
@@ -40,7 +40,7 @@ ARMBIAN_IMG=""
 ARMBIAN_VERSION=""
 ARMBIAN_KERNEL_VERSION=""
 # Offset of the Armbian image for rootfs, in 512 bytes sectors
-ARMBIAN_IMG_OFFSET="32768"
+ARMBIAN_IMG_OFFSET="8192"
 # this is a base name, we will work with partitions
 BASE_IMG=${TIMAGE_DIR}/base_image
 # how much will we increase the original image in MB

--- a/build.sh
+++ b/build.sh
@@ -78,7 +78,7 @@ function error() {
 function tool_test() {
     # info
     info "Testing the workspace for needed tools"
-    for t in ${NEEDED_TOOLS} ; do 
+    for t in ${NEEDED_TOOLS} ; do
         local BIN=`which ${t}`
         if [ -z "${BIN}" ] ; then
             # not found
@@ -93,8 +93,8 @@ function tool_test() {
 }
 
 
-# Build the output/work folder structure, this is excluded from the git 
-# tracking on purpose: this will generate GB of data on each push  
+# Build the output/work folder structure, this is excluded from the git
+# tracking on purpose: this will generate GB of data on each push
 function create_folders() {
     # output [main folder]
     #   /final [this will be the final images dir]
@@ -154,7 +154,7 @@ function get_armbian() {
             # we can not reuse it, must download, so erase it
             warn "Old copy detected but you stated not to reuse it"
             rm -f "armbian.7z" &> /dev/null || true
-            
+
             # get it
             info "Downloading..."
             download_armbian
@@ -172,7 +172,7 @@ function get_armbian() {
 
     # if you get to this point then reset to the actual filename
     ARMBIAN_IMG_7z="armbian.7z"
-    
+
     # extract and check it's integrity
     info "Armbian file to process is:"
     info "'${ARMBIAN_IMG_7z}'"
@@ -197,7 +197,7 @@ function get_armbian() {
 
     # check integrity
     info "Testing image integrity..."
-    `which sha256sum` -c --status sha256sum.sha
+    `which sha256sum` -c --status *.sha
 
     # check for correct extraction
     if [ $? -ne 0 ] ; then
@@ -216,7 +216,7 @@ function get_armbian() {
     # get version & kernel version info
     ARMBIAN_VERSION=`echo ${ARMBIAN_IMG} | awk -F '_' '{ print $2 }'`
     ARMBIAN_KERNEL_VERSION=`echo ${ARMBIAN_IMG} | awk -F '_' '{ print $7 }' | rev | cut -d '.' -f2- | rev`
-    
+
     # info to the user
     notice "Armbian version: ${ARMBIAN_VERSION}"
     notice "Armbian kernel version: ${ARMBIAN_KERNEL_VERSION}"
@@ -303,7 +303,7 @@ function find_free_loop() {
         DEV=`awk -v min=20 -v max=99 'BEGIN{srand(); print int(min+rand()*(max-min+1))}'`
         OUT=`losetup | grep /dev/loop$DEV || true`
     done
-    
+
     # output to other function
     echo "/dev/loop$DEV"
 }
@@ -324,7 +324,7 @@ function increase_image_size() {
     info "Preparing the Armbian image."
     rm "${BASE_IMG}" &> /dev/null || true
     cp "${DOWNLOADS_DIR}/armbian/${ARMBIAN_IMG}" "${BASE_IMG}"
-    
+
     # create the added space file
     info "Adding ${BASE_IMG_ADDED_SPACE}MB of extra space to the image."
     truncate -s +"${BASE_IMG_ADDED_SPACE}M" "${BASE_IMG}"
@@ -376,7 +376,7 @@ function build_disk() {
     # TODO [TEST]
     # shrink the partition to a minimum size
     # sudo resize2fs -M "${IMG_LOOP}"
-    # 
+    #
     # shrink the partition
 
     # force a FS sync
@@ -477,18 +477,18 @@ function get_n_install_skywire() {
 
 # enable chroot
 function enable_chroot() {
-    # copy the aarm64 static exec to be able to execute 
+    # copy the aarm64 static exec to be able to execute
     # things on the internal chroot
     AARM64=`which qemu-aarch64-static`
 
     # log
-    info "Setup of the chroot jail to be able to exec command inside the roofs." 
+    info "Setup of the chroot jail to be able to exec command inside the roofs."
 
     # copy the static bin
     sudo cp ${AARM64} ${FS_MNT_POINT}/usr/bin/
 
     # some required mounts
-    info "Mapping special mounts inside the chroot" 
+    info "Mapping special mounts inside the chroot"
     sudo mount -t sysfs none ${FS_MNT_POINT}/sys
     sudo mount -t proc none ${FS_MNT_POINT}/proc
     sudo mount --bind /dev ${FS_MNT_POINT}/dev
@@ -502,7 +502,7 @@ function disable_chroot() {
     AARM64="qemu-aarch64-static"
 
     # log
-    info "Disable the chroot jail." 
+    info "Disable the chroot jail."
 
     # remove the static bin
     sudo rm ${FS_MNT_POINT}/usr/bin/${AARM64}
@@ -567,7 +567,7 @@ function fix_armian_defaults() {
 }
 
 
-# setup the rootfs to a loop device 
+# setup the rootfs to a loop device
 function setup_loop() {
     # find a free loopdevice and set it on the environment
     IMG_LOOP=`find_free_loop`
@@ -587,7 +587,7 @@ function rootfs_check() {
     info "Starting a FS check"
     # local var to trap exit status
     out=0
-    sudo e2fsck -fpD "${IMG_LOOP}" || out=$? && true 
+    sudo e2fsck -fpD "${IMG_LOOP}" || out=$? && true
     # testing exit status
     if [ $out -gt 2 ] ; then
         error "Uncorrected errors while checking the fs, build stoped"

--- a/static/chroot_passwd.sh
+++ b/static/chroot_passwd.sh
@@ -2,4 +2,4 @@
 
 # change root password to the default of: skybian
 
-echo "root:skybian" | chpasswd
+printf "skybian\nskybian\n" | passwd root


### PR DESCRIPTION
chpasswd is only available on debian-based distros


Fixes #1 

Changes:
-

Does this change need to mentioned in CHANGELOG.md?

No

