### PR TITLE
Update skywire-startup.service

### DIFF
--- a/static/skywire-startup.service
+++ b/static/skywire-startup.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Skywire Startup
 After=network.target
+After=NetworkManager.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
Fixes #

Changes:
NetworkManager.service needs to be running before the skywire-startup.service

Does this change need to mentioned in CHANGELOG.md?

No?

