### PR TITLE
Feature/cancel image download

### DIFF
--- a/pkg/imager/builder.go
+++ b/pkg/imager/builder.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mholt/archiver"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
 
 	"github.com/skycoin/skybian/pkg/boot"
 )
@@ -86,11 +87,11 @@ func (b *Builder) DownloadCurrent() int64 {
 }
 
 // Download starts downloading from the given URL.
-func (b *Builder) Download(url string) error {
+func (b *Builder) Download(ctx context.Context, url string) error {
 	b.mx.Lock()
 	defer b.mx.Unlock()
 
-	return Download(b.log, url, b.DownloadPath(), &b.dlTotal, &b.dlCurrent)
+	return Download(ctx, b.log, url, b.DownloadPath(), &b.dlTotal, &b.dlCurrent)
 }
 
 // ExtractArchive extracts the downloaded archive.

--- a/pkg/imager/cli_build.go
+++ b/pkg/imager/cli_build.go
@@ -1,6 +1,7 @@
 package imager
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -33,7 +34,7 @@ func CLIBuild(log logrus.FieldLogger, root, dlURL string, bpsSlice []boot.Params
 	dlErr := make(chan error, 1)
 	dlT := time.NewTicker(time.Second * 1)
 	go func() {
-		dlErr <- builder.Download(dlURL)
+		dlErr <- builder.Download(context.Background(), dlURL)
 		close(dlErr)
 	}()
 

--- a/pkg/imager/download.go
+++ b/pkg/imager/download.go
@@ -1,7 +1,6 @@
 package imager
 
 import (
-	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -11,8 +10,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
-
-var errDownloadCanceled = errors.New("download canceled")
 
 func Download(ctx context.Context, log logrus.FieldLogger, url, dst string, total, current *int64) error {
 	log = log.WithField("func", "Download")
@@ -48,10 +45,6 @@ func Download(ctx context.Context, log logrus.FieldLogger, url, dst string, tota
 	// Also record progress in 'current' via writeCounter{}.
 	w := io.MultiWriter(f, &writeCounter{current: current})
 	if _, err := io.Copy(w, resp.Body); err != nil {
-		if errors.Is(err, context.Canceled) {
-			log.Info("Download process was canceled by user")
-			return errDownloadCanceled
-		}
 		log.WithError(err).Error("Failed to write file.")
 		return err
 	}

--- a/pkg/imager/download.go
+++ b/pkg/imager/download.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-var errDownloadCanceled = errors.New("Download canceled")
+var errDownloadCanceled = errors.New("download canceled")
 
 func Download(ctx context.Context, log logrus.FieldLogger, url, dst string, total, current *int64) error {
 	log = log.WithField("func", "Download")
@@ -30,9 +30,8 @@ func Download(ctx context.Context, log logrus.FieldLogger, url, dst string, tota
 	if err != nil {
 		return err
 	}
-	client := &http.Client{}
 
-	resp, err := client.Do(request)
+	resp, err := http.DefaultClient.Do(request)
 	if err != nil {
 		return err
 	}

--- a/pkg/imager/fyne.go
+++ b/pkg/imager/fyne.go
@@ -158,10 +158,10 @@ func (fg *FyneUI) build() {
 
 	switch fg.imgLoc {
 	case fg.locations[0]:
-		ctx, cancelF := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(context.Background())
 		dlTitle := "Downloading Base Image"
 		dlMsg := fg.remImg + "\n" + baseURL
-		dlDialog := widgets.NewProgress(dlTitle, dlMsg, fg.w, cancelF, "Cancel")
+		dlDialog := widgets.NewProgress(dlTitle, dlMsg, fg.w, cancel, "Cancel")
 
 		dlDialog.Show()
 
@@ -187,6 +187,7 @@ func (fg *FyneUI) build() {
 		dlDialog.Hide()
 		if err != nil {
 			if !errors.Is(err, errDownloadCanceled) {
+				fg.log.Errorf("Error when downloading image %v", err)
 				dialog.ShowError(err, fg.w)
 			}
 			return

--- a/pkg/imager/fyne.go
+++ b/pkg/imager/fyne.go
@@ -166,9 +166,6 @@ func (fg *FyneUI) build() {
 		dlDialog.Show()
 
 		// Download section.
-
-		// dlDialog := dialog.NewProgress(dlTitle, dlMsg, fg.w)
-		dlDialog.Show()
 		dlDone := make(chan struct{})
 		go func() {
 			t := time.NewTicker(time.Second)

--- a/pkg/imager/fyne.go
+++ b/pkg/imager/fyne.go
@@ -189,6 +189,8 @@ func (fg *FyneUI) build() {
 			if !errors.Is(err, errDownloadCanceled) {
 				fg.log.Errorf("Error when downloading image %v", err)
 				dialog.ShowError(err, fg.w)
+			} else {
+				fg.log.Info("Download canceled by user")
 			}
 			return
 		}

--- a/pkg/imager/widgets/dialogs.go
+++ b/pkg/imager/widgets/dialogs.go
@@ -1,0 +1,208 @@
+package widgets
+
+import (
+	"image/color"
+
+	"fyne.io/fyne"
+	"fyne.io/fyne/canvas"
+	"fyne.io/fyne/layout"
+	"fyne.io/fyne/theme"
+	"fyne.io/fyne/widget"
+)
+
+const (
+	padWidth  = 32
+	padHeight = 16
+)
+
+type skydialog struct {
+	callback func(bool)
+	title    string
+	icon     fyne.Resource
+
+	win            *widget.PopUp
+	bg             *canvas.Rectangle
+	content, label fyne.CanvasObject
+	dismiss        *widget.Button
+
+	response  chan bool
+	responded bool
+	parent    fyne.Window
+}
+
+func (d *skydialog) wait() {
+	select {
+	case response := <-d.response:
+		d.responded = true
+		d.win.Hide()
+		if d.callback != nil {
+			d.callback(response)
+		}
+	}
+}
+
+func (d *skydialog) setButtons(buttons fyne.CanvasObject) {
+	d.bg = canvas.NewRectangle(theme.BackgroundColor())
+	d.label = widget.NewLabelWithStyle(d.title, fyne.TextAlignLeading, fyne.TextStyle{Bold: true})
+
+	var content fyne.CanvasObject
+	if d.icon == nil {
+		content = fyne.NewContainerWithLayout(d,
+			&canvas.Image{},
+			d.bg,
+			d.content,
+			buttons,
+			d.label,
+		)
+	} else {
+		bgIcon := canvas.NewImageFromResource(d.icon)
+		content = fyne.NewContainerWithLayout(d,
+			bgIcon,
+			d.bg,
+			d.content,
+			buttons,
+			d.label,
+		)
+	}
+
+	d.win = widget.NewModalPopUp(content, d.parent.Canvas())
+	d.applyTheme()
+}
+
+func (d *skydialog) Layout(obj []fyne.CanvasObject, size fyne.Size) {
+	d.bg.Move(fyne.NewPos(-theme.Padding(), -theme.Padding()))
+	d.bg.Resize(size.Add(fyne.NewSize(theme.Padding()*2, theme.Padding()*2)))
+
+	textMin := obj[2].MinSize()
+	btnMin := obj[3].MinSize().Union(obj[3].Size())
+
+	// icon
+	iconHeight := padHeight*2 + textMin.Height + d.label.MinSize().Height - theme.Padding()
+	obj[0].Resize(fyne.NewSize(iconHeight, iconHeight))
+	obj[0].Move(fyne.NewPos(size.Width-iconHeight+theme.Padding(), -theme.Padding()))
+
+	// content (text)
+	obj[2].Move(fyne.NewPos(size.Width/2-(textMin.Width/2), size.Height-padHeight-btnMin.Height-textMin.Height-theme.Padding()))
+	obj[2].Resize(fyne.NewSize(textMin.Width, textMin.Height))
+
+	// buttons
+	obj[3].Resize(btnMin)
+	obj[3].Move(fyne.NewPos(size.Width/2-(btnMin.Width/2), size.Height-padHeight-btnMin.Height))
+}
+
+func (d *skydialog) MinSize(obj []fyne.CanvasObject) fyne.Size {
+	textMin := obj[2].MinSize()
+	btnMin := obj[3].MinSize().Union(obj[3].Size())
+
+	width := fyne.Max(fyne.Max(textMin.Width, btnMin.Width), obj[4].MinSize().Width) + padWidth*2
+	height := textMin.Height + btnMin.Height + d.label.MinSize().Height + theme.Padding() + padHeight*2
+
+	return fyne.NewSize(width, height)
+}
+
+func (d *skydialog) applyTheme() {
+	r, g, b, _ := theme.BackgroundColor().RGBA()
+	bg := &color.RGBA{R: uint8(r), G: uint8(g), B: uint8(b), A: 230}
+	d.bg.FillColor = bg
+}
+
+func newDialog(title, message string, icon fyne.Resource, callback func(bool), parent fyne.Window) *skydialog {
+	d := &skydialog{content: newLabel(message), title: title, icon: icon, parent: parent}
+
+	d.response = make(chan bool, 1)
+	d.callback = callback
+
+	return d
+}
+
+func newLabel(message string) fyne.CanvasObject {
+	return widget.NewLabelWithStyle(message, fyne.TextAlignCenter, fyne.TextStyle{})
+}
+
+func (d *skydialog) Show() {
+	go d.wait()
+	d.win.Show()
+}
+
+func (d *skydialog) Hide() {
+	d.win.Hide()
+
+	if !d.responded && d.callback != nil {
+		d.callback(false)
+	}
+}
+
+// SetDismissText allows custom text to be set in the confirmation button
+func (d *skydialog) SetDismissText(label string) {
+	d.dismiss.SetText(label)
+	widget.Refresh(d.win)
+}
+
+// ShowCustom shows a skydialog over the specified application using custom
+// content. The button will have the dismiss text set.
+// The MinSize() of the CanvasObject passed will be used to set the size of the window.
+func ShowCustom(title, dismiss string, content fyne.CanvasObject, parent fyne.Window) {
+	d := &skydialog{content: content, title: title, icon: nil, parent: parent}
+	d.response = make(chan bool, 1)
+
+	d.dismiss = &widget.Button{Text: dismiss,
+		OnTapped: func() {
+			d.response <- false
+		},
+	}
+	d.setButtons(widget.NewHBox(layout.NewSpacer(), d.dismiss, layout.NewSpacer()))
+
+	d.Show()
+}
+
+// ShowCustomConfirm shows a skydialog over the specified application using custom
+// content. The cancel button will have the dismiss text set and the "OK" will use
+// the confirm text. The response callback is called on user action.
+// The MinSize() of the CanvasObject passed will be used to set the size of the window.
+func ShowCustomConfirm(title, confirm, dismiss string, content fyne.CanvasObject,
+	callback func(bool), parent fyne.Window) {
+	d := &skydialog{content: content, title: title, icon: nil, parent: parent}
+	d.response = make(chan bool, 1)
+	d.callback = callback
+
+	d.dismiss = &widget.Button{Text: dismiss, Icon: theme.CancelIcon(),
+		OnTapped: func() {
+			d.response <- false
+		},
+	}
+	ok := &widget.Button{Text: confirm, Icon: theme.ConfirmIcon(), Style: widget.PrimaryButton,
+		OnTapped: func() {
+			d.response <- true
+		},
+	}
+	d.setButtons(widget.NewHBox(layout.NewSpacer(), d.dismiss, ok, layout.NewSpacer()))
+
+	d.Show()
+}
+
+// ProgressDialog is a simple skydialog window that displays text and a progress bar.
+type ProgressDialog struct {
+	*skydialog
+
+	bar *widget.ProgressBar
+}
+
+// SetValue updates the value of the progress bar - this should be between 0.0 and 1.0.
+func (p *ProgressDialog) SetValue(v float64) {
+	p.bar.SetValue(v)
+}
+
+// NewProgress creates a progress skydialog and returns the handle.
+// Using the returned type you should call Show() and then set its value through SetValue().
+func NewProgress(title, message string, parent fyne.Window, cancelF func(), cancelText string) *ProgressDialog {
+	d := newDialog(title, message, theme.InfoIcon(), nil /*cancel?*/, parent)
+	bar := widget.NewProgressBar()
+	cancelBtn := &widget.Button{Text: cancelText, Icon: theme.CancelIcon(),
+		OnTapped: func() {
+			cancelF()
+			d.response <- false
+		}}
+	content := widget.NewVBox(bar, cancelBtn)
+	d.setButtons(content)
+	return &ProgressDialog{d, bar}
+}

--- a/pkg/imager/widgets/dialogs.go
+++ b/pkg/imager/widgets/dialogs.go
@@ -10,6 +10,14 @@ import (
 	"fyne.io/fyne/widget"
 )
 
+// This package has been mostly copied from fyne/dialog
+// The reason of this was that fyne/dialog doesn't provide any easy
+// way to extend its widgets and to add custom content
+
+// Another solution would be to write our own widget from scratch,
+// but there isn't much point in it since fyne/dialog implementation
+// covers the basic functionality of showing/hiding a window already
+
 const (
 	padWidth  = 32
 	padHeight = 16
@@ -138,7 +146,7 @@ func (d *skydialog) SetDismissText(label string) {
 	widget.Refresh(d.win)
 }
 
-// ShowCustom shows a skydialog over the specified application using custom
+// ShowCustom shows a dialog over the specified application using custom
 // content. The button will have the dismiss text set.
 // The MinSize() of the CanvasObject passed will be used to set the size of the window.
 func ShowCustom(title, dismiss string, content fyne.CanvasObject, parent fyne.Window) {
@@ -155,7 +163,7 @@ func ShowCustom(title, dismiss string, content fyne.CanvasObject, parent fyne.Wi
 	d.Show()
 }
 
-// ShowCustomConfirm shows a skydialog over the specified application using custom
+// ShowCustomConfirm shows a dialog over the specified application using custom
 // content. The cancel button will have the dismiss text set and the "OK" will use
 // the confirm text. The response callback is called on user action.
 // The MinSize() of the CanvasObject passed will be used to set the size of the window.
@@ -180,7 +188,7 @@ func ShowCustomConfirm(title, confirm, dismiss string, content fyne.CanvasObject
 	d.Show()
 }
 
-// ProgressDialog is a simple skydialog window that displays text and a progress bar.
+// ProgressDialog is a simple dialog window that displays text and a progress bar.
 type ProgressDialog struct {
 	*skydialog
 
@@ -192,8 +200,10 @@ func (p *ProgressDialog) SetValue(v float64) {
 	p.bar.SetValue(v)
 }
 
-// NewProgress creates a progress skydialog and returns the handle.
-// Using the returned type you should call Show() and then set its value through SetValue().
+// NewProgress creates a progress dialog and returns the handle.
+// Using the returned type you should call Show() and then set its value through SetValue()
+// cancelF will be called upon pressing the cancel button
+// cancelText will be shown on the cancel button
 func NewProgress(title, message string, parent fyne.Window, cancelF func(), cancelText string) *ProgressDialog {
 	d := newDialog(title, message, theme.InfoIcon(), nil /*cancel?*/, parent)
 	bar := widget.NewProgressBar()


### PR DESCRIPTION
Fixes #60 

Changes:
- Add cancel button to image download progress dialog

Does this change need to mentioned in CHANGELOG.md?

No

Implementation notes

Unfortunately fyne dialog widget doesn't seem to be extensible enough to implement this seemingly simple feature.
I copied over generic dialog widget from fyne and added a canclelable progress dialog implementation `ProgressDialog` in the project package.

