### PR TITLE
Feature/add wifi config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,6 @@ require (
 	github.com/skycoin/skywire v0.3.0
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 // indirect
+	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 	nhooyr.io/websocket v1.8.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,7 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.5.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/integration/cmd/mock_mbr.go
+++ b/integration/cmd/mock_mbr.go
@@ -34,10 +34,10 @@ func main() {
 	switch mode {
 	case 0:
 		// Hypervisor
-		bp, err = boot.MakeHypervisorParams(gwIP, sk)
+		bp, err = boot.MakeHypervisorParams(gwIP, sk, "", "")
 	case 1:
 		// Visor.
-		bp, err = boot.MakeVisorParams(gwIP, gwIP, sk, makeHvPKs(), "123456")
+		bp, err = boot.MakeVisorParams(gwIP, gwIP, sk, makeHvPKs(), "123456", "", "")
 	default:
 		err = errors.New("invalid mode")
 	}

--- a/pkg/boot/params.go
+++ b/pkg/boot/params.go
@@ -35,6 +35,8 @@ const (
 	LocalSKENV       = "SK"
 	HypervisorPKsENV = "HVS"
 	SocksPassEnv     = "SS"
+	WifiNameEnv      = "WFN"
+	WifiPassEnv      = "WFP"
 )
 
 // Modes.
@@ -227,6 +229,14 @@ func (bp Params) PrintEnvs(w io.Writer) error {
 	}
 	if len(bp.SkysocksPasscode) > 0 {
 		if err := PrintEnv(w, SocksPassEnv, bp.SkysocksPasscode); err != nil {
+			return err
+		}
+	}
+	if len(bp.WifiEndpointName) > 0 && len(bp.WifiEndpointPass) > 0 {
+		if err := PrintEnv(w, WifiNameEnv, bp.WifiEndpointName); err != nil {
+			return err
+		}
+		if err := PrintEnv(w, WifiPassEnv, bp.WifiEndpointPass); err != nil {
 			return err
 		}
 	}

--- a/pkg/boot/params.go
+++ b/pkg/boot/params.go
@@ -251,11 +251,8 @@ func (bp Params) PrintEnvs(w io.Writer) error {
 // Encode encodes the boot parameters in a concise format to be wrote to the MBR.
 func (bp Params) Encode() ([]byte, error) {
 	keys := bp.LocalSK[:]
-	toEncode := [][]byte{{byte(bp.Mode)}, bp.LocalIP, bp.GatewayIP, []byte(bp.SkysocksPasscode)}
-	if bp.WifiEndpointName != "" && bp.WifiEndpointPass != "" {
-		toEncode = append(toEncode, []byte(bp.WifiEndpointName))
-		toEncode = append(toEncode, []byte(bp.WifiEndpointPass))
-	}
+	toEncode := [][]byte{{byte(bp.Mode)}, bp.LocalIP, bp.GatewayIP,
+		[]byte(bp.SkysocksPasscode), []byte(bp.WifiEndpointName), []byte(bp.WifiEndpointPass)}
 	for _, hvPK := range bp.HypervisorPKs {
 		keys = append(keys, hvPK[:]...)
 	}
@@ -274,7 +271,7 @@ func (bp Params) Encode() ([]byte, error) {
 func (bp *Params) Decode(raw []byte) error {
 	split := bytes.SplitN(raw, []byte{sep}, 7)
 	// 5 for a regular config, 7 for wifi-enabled config
-	if len(split) != 5 && len(split) != 7 {
+	if len(split) != 7 {
 		return ErrCannotReadParams
 	}
 

--- a/pkg/imager/fyne.go
+++ b/pkg/imager/fyne.go
@@ -39,16 +39,18 @@ type FyneUI struct {
 	releases  []Release
 	locations []string
 
-	wkDir   string
-	imgLoc  string
-	remImg  string
-	fsImg   string
-	gwIP    net.IP
-	socksPC string
-	visors  int
-	hvImg   bool
-	hvPKs   []cipher.PubKey
-	bps     []boot.Params
+	wkDir    string
+	imgLoc   string
+	remImg   string
+	fsImg    string
+	gwIP     net.IP
+	wifiName string
+	wifiPass string
+	socksPC  string
+	visors   int
+	hvImg    bool
+	hvPKs    []cipher.PubKey
+	bps      []boot.Params
 }
 
 // NewFyneUI creates a new Fyne UI.
@@ -114,7 +116,7 @@ func (fg *FyneUI) generateBPS() (string, error) {
 	hvPKs := fg.hvPKs
 	if fg.hvImg {
 		hvPK, hvSK := cipher.GenerateKeyPair()
-		hvBps, err := boot.MakeHypervisorParams(fg.gwIP, hvSK, "test", "test_pass")
+		hvBps, err := boot.MakeHypervisorParams(fg.gwIP, hvSK, fg.wifiName, fg.wifiPass)
 		if err != nil {
 			return "", fmt.Errorf("boot_params[%d]: failed to generate for hypervisor: %v", len(bpsSlice), err)
 		}
@@ -124,7 +126,7 @@ func (fg *FyneUI) generateBPS() (string, error) {
 	}
 	for i := 0; i < fg.visors; i++ {
 		_, vSK := cipher.GenerateKeyPair()
-		vBps, err := boot.MakeVisorParams(prevIP, fg.gwIP, vSK, hvPKs, fg.socksPC, "test", "test_pass")
+		vBps, err := boot.MakeVisorParams(prevIP, fg.gwIP, vSK, hvPKs, fg.socksPC, fg.wifiName, fg.wifiPass)
 		if err != nil {
 			return "", fmt.Errorf("boot_params[%d]: failed to generate for visor: %v", len(bpsSlice), err)
 		}

--- a/pkg/imager/fyne.go
+++ b/pkg/imager/fyne.go
@@ -114,7 +114,7 @@ func (fg *FyneUI) generateBPS() (string, error) {
 	hvPKs := fg.hvPKs
 	if fg.hvImg {
 		hvPK, hvSK := cipher.GenerateKeyPair()
-		hvBps, err := boot.MakeHypervisorParams(fg.gwIP, hvSK)
+		hvBps, err := boot.MakeHypervisorParams(fg.gwIP, hvSK, "test", "test_pass")
 		if err != nil {
 			return "", fmt.Errorf("boot_params[%d]: failed to generate for hypervisor: %v", len(bpsSlice), err)
 		}
@@ -124,7 +124,7 @@ func (fg *FyneUI) generateBPS() (string, error) {
 	}
 	for i := 0; i < fg.visors; i++ {
 		_, vSK := cipher.GenerateKeyPair()
-		vBps, err := boot.MakeVisorParams(prevIP, fg.gwIP, vSK, hvPKs, fg.socksPC)
+		vBps, err := boot.MakeVisorParams(prevIP, fg.gwIP, vSK, hvPKs, fg.socksPC, "test", "test_pass")
 		if err != nil {
 			return "", fmt.Errorf("boot_params[%d]: failed to generate for visor: %v", len(bpsSlice), err)
 		}

--- a/pkg/imager/fyne_pages.go
+++ b/pkg/imager/fyne_pages.go
@@ -106,6 +106,32 @@ func (fg *FyneUI) Page2() fyne.CanvasObject {
 		fg.log.Debugf("Set: fg.gwIP = %v", s)
 	})
 
+	wifiName := newEntry(fg.wifiName, func(s string) {
+		fg.wifiName = s
+		fg.log.Debugf("Set: fg.gwIP = %v", s)
+	})
+	wifiPass := newEntry(fg.wifiPass, func(s string) {
+		fg.wifiPass = s
+		fg.log.Debugf("Set: fg.wifiPass = %v", s)
+	})
+
+	wifiWidgets := fyne.NewContainerWithLayout(layout.NewVBoxLayout(), widget.NewLabel("Wifi access point name:"),
+		wifiName, widget.NewLabel("Wifi passcode:"), wifiPass)
+	wifiWidgets.Hide()
+
+	enableWifi := widget.NewCheck("Generate wi-fi connection", func(b bool) {
+		if b {
+			fg.wifiName = wifiName.Text
+			fg.wifiPass = wifiPass.Text
+			wifiWidgets.Show()
+		} else {
+			fg.wifiName = ""
+			fg.wifiPass = ""
+			wifiWidgets.Hide()
+		}
+	})
+	enableWifi.SetChecked(false)
+
 	socksPC := newLinkedEntry(&fg.socksPC)
 	socksPC.SetPlaceHolder("passcode")
 
@@ -204,6 +230,8 @@ func (fg *FyneUI) Page2() fyne.CanvasObject {
 		widget.NewLabel("Work Directory:"), wkDir,
 		widget.NewLabel("Base Image:"), imgLoc, remImg, fsImgPicker,
 		widget.NewLabel("Gateway IP:"), gwIP,
+		enableWifi,
+		wifiWidgets,
 		widget.NewLabel("Skysocks Passcode:"), socksPC,
 		widget.NewLabel("Number of Visor Images:"), visors,
 		genHvImg, enableHvPKs, hvPKs, hvPKsAdd)

--- a/static/skybian-firstrun
+++ b/static/skybian-firstrun
@@ -78,28 +78,29 @@ setup_network || exit 1
 
 setup_wifi()
 {
-  if [[ -n "$WFN" ]]; then
-    echo "Setting up wifi connection $WIFI_NAME..."
-    nmcli c add type wifi con-name "$WIFI_NAME" ifname wlan0 ssid $WFN
-    if [[ -n "$WFP" ]]; then
-      nmcli c modify "$WIFI_NAME" wifi-sec.key-mgmt wpa-psk wifi-sec.psk $WFP
-    fi
-
-    if [[ -n "$IP" && -n "$GW" ]]; then
-      echo "Setting manual IP to $IP for $WIFI_NAME."
-      nmcli con mod "$WIFI_NAME" ipv4.addresses "$IP/24" ipv4.method "manual"
-    fi
-
-    if [[ -n "$GW" ]]; then
-      echo "Setting manual Gateway IP to $GW for $WIFI_NAME."
-      nmcli con mod "$WIFI_NAME" ipv4.gateway "$GW"
-    fi
-    nmcli con mod "$WIFI_NAME" ipv4.dns "1.0.0.1, 1.1.1.1"
-    nmcli con down "$WIFI_NAME"
-    nmcli con up "$WIFI_NAME"
+  echo "Setting up wifi connection $WIFI_NAME..."
+  nmcli c add type wifi con-name "$WIFI_NAME" ifname wlan0 ssid $WFN
+  if [[ -n "$WFP" ]]; then
+    nmcli c modify "$WIFI_NAME" wifi-sec.key-mgmt wpa-psk wifi-sec.psk $WFP
   fi
+
+  if [[ -n "$IP" && -n "$GW" ]]; then
+    echo "Setting manual IP to $IP for $WIFI_NAME."
+    nmcli con mod "$WIFI_NAME" ipv4.addresses "$IP/24" ipv4.method "manual"
+  fi
+
+  if [[ -n "$GW" ]]; then
+    echo "Setting manual Gateway IP to $GW for $WIFI_NAME."
+    nmcli con mod "$WIFI_NAME" ipv4.gateway "$GW"
+  fi
+  nmcli con mod "$WIFI_NAME" ipv4.dns "1.0.0.1, 1.1.1.1"
+  nmcli con down "$WIFI_NAME"
+  nmcli con up "$WIFI_NAME"
 }
-setup_wifi || exit 1
+
+if [[ -n "$WFN" ]]; then
+  setup_wifi || exit 1
+fi
 
 for file in /etc/ssh/ssh_host* ; do
     echo "[skybian-firstrun] Checking $file:"

--- a/static/skybian-firstrun
+++ b/static/skybian-firstrun
@@ -13,6 +13,7 @@ TLS_KEY=/etc/skywire-hypervisor/key.pem
 TLS_CERT=/etc/skywire-hypervisor/cert.pem
 
 NET_NAME="Wired connection 1"
+WIFI_NAME="Wireless connection 1"
 
 # Stop here if config files are already generated.
 if [[ -f "$VISOR_CONF" || -f "$HYPERVISOR_CONF" ]]; then
@@ -74,6 +75,29 @@ setup_network()
   nmcli con mod "$NET_NAME" ipv4.dns "1.0.0.1, 1.1.1.1"
 }
 setup_network || exit 1
+
+setup_wifi()
+{
+  if [[ -n "$WFN" ]]; then
+    echo "Setting up wifi connection $WIFI_NAME..."
+    nmcli c add type wifi con-name $WIFI_NAME ifname wlan0 ssid $WFN
+    if [[ -n "$WFP" ]]; then
+      nmcli c modify $WIFI_NAME wifi-sec.key-mgmt wpa-psk wifi-sec.psk $WFP
+    fi
+
+    if [[ -n "$IP" && -n "$GW" ]]; then
+      echo "Setting manual IP to $IP for $WIFI_NAME."
+      nmcli con mod "$WIFI_NAME" ipv4.addresses "$IP/24" ipv4.method "manual"
+    fi
+
+    if [[ -n "$GW" ]]; then
+      echo "Setting manual Gateway IP to $GW for $WIFI_NAME."
+      nmcli con mod "$WIFI_NAME" ipv4.gateway "$GW"
+    fi
+    nmcli con mod "$WIFI_NAME" ipv4.dns "1.0.0.1, 1.1.1.1"
+  fi
+}
+setup_wifi || exit 1
 
 for file in /etc/ssh/ssh_host* ; do
     echo "[skybian-firstrun] Checking $file:"

--- a/static/skybian-firstrun
+++ b/static/skybian-firstrun
@@ -95,6 +95,7 @@ setup_wifi()
   fi
   nmcli con mod "$WIFI_NAME" ipv4.dns "1.0.0.1, 1.1.1.1"
   nmcli con down "$WIFI_NAME"
+  sleep 3
   nmcli con up "$WIFI_NAME"
 }
 

--- a/static/skybian-firstrun
+++ b/static/skybian-firstrun
@@ -80,9 +80,9 @@ setup_wifi()
 {
   if [[ -n "$WFN" ]]; then
     echo "Setting up wifi connection $WIFI_NAME..."
-    nmcli c add type wifi con-name $WIFI_NAME ifname wlan0 ssid $WFN
+    nmcli c add type wifi con-name "$WIFI_NAME" ifname wlan0 ssid $WFN
     if [[ -n "$WFP" ]]; then
-      nmcli c modify $WIFI_NAME wifi-sec.key-mgmt wpa-psk wifi-sec.psk $WFP
+      nmcli c modify "$WIFI_NAME" wifi-sec.key-mgmt wpa-psk wifi-sec.psk $WFP
     fi
 
     if [[ -n "$IP" && -n "$GW" ]]; then

--- a/static/skybian-firstrun
+++ b/static/skybian-firstrun
@@ -95,6 +95,8 @@ setup_wifi()
       nmcli con mod "$WIFI_NAME" ipv4.gateway "$GW"
     fi
     nmcli con mod "$WIFI_NAME" ipv4.dns "1.0.0.1, 1.1.1.1"
+    nmcli con down "$WIFI_NAME"
+    nmcli con up "$WIFI_NAME"
   fi
 }
 setup_wifi || exit 1


### PR DESCRIPTION
Fixes #54

Changes:
- Adds new fields to the UI when building an image, allowing to setup wifi for skybian headlessly

Does this change need to mentioned in CHANGELOG.md?

Yes 

To test this:
1. Checkout this branch
2. Build skyconf with `make build-skyconf`
3. Build base image with `make build-skybian-img`
4. Run skyimager gui: `go run cmd/skyimager-gui/skyimager-gui.go`
5. Fill in your configuration. Choose `output/final/Skybian-v0.1.3.img` file as a base image (generated at step 3), and select 0 additional visor images (one image is sufficient for testing).
6. On page 3 of the GUI builder copy IP address of the final image (change if needed)
7. Flash resulting image (`~/skyimager/final/image-0.img`) onto a flash disk
8. Insert flash disk into your board and boot
9. Ping the IP address from step 6
