### PR TITLE
Add 24bit subnet mask to wired connection

### DIFF
--- a/static/skybian-firstrun
+++ b/static/skybian-firstrun
@@ -63,7 +63,7 @@ setup_network()
 
   if [[ -n "$IP" ]]; then
     echo "Setting manual IP to $IP for $NET_NAME."
-    nmcli con mod "$NET_NAME" ipv4.addresses "$IP"/24 ipv4.method "manual"
+    nmcli con mod "$NET_NAME" ipv4.addresses "$IP/24" ipv4.method "manual"
   fi
 
   if [[ -n "$GW" ]]; then

--- a/static/skybian-firstrun
+++ b/static/skybian-firstrun
@@ -63,7 +63,7 @@ setup_network()
 
   if [[ -n "$IP" ]]; then
     echo "Setting manual IP to $IP for $NET_NAME."
-    nmcli con mod "$NET_NAME" ipv4.addresses "$IP" ipv4.method "manual"
+    nmcli con mod "$NET_NAME" ipv4.addresses "$IP"/24 ipv4.method "manual"
   fi
 
   if [[ -n "$GW" ]]; then


### PR DESCRIPTION
Fixes #72

Changes:
- Adds 24 bit subnet mask when creating wired connection

Does this change need to mentioned in CHANGELOG.md?

No
