### PR TITLE
Use text wrapping for error dialogs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,6 @@ require (
 	github.com/skycoin/skywire v0.3.0
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 // indirect
+	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 	nhooyr.io/websocket v1.8.4 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,7 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.5.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/imager/fyne.go
+++ b/pkg/imager/fyne.go
@@ -100,7 +100,7 @@ func (fg *FyneUI) listBaseImgs() ([]string, string) {
 		} else {
 			message = err.Error()
 		}
-		showDialogErrMessage(message, fg.w)
+		widgets.ShowError(message, fg.w)
 		return nil, ""
 	}
 

--- a/pkg/imager/fyne_helpers.go
+++ b/pkg/imager/fyne_helpers.go
@@ -1,7 +1,6 @@
 package imager
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -68,10 +67,6 @@ func showErr(fg *FyneUI, err ...error) bool {
 		dialog.ShowError(e, fg.w)
 	}
 	return false
-}
-
-func showDialogErrMessage(errMessage string, fw fyne.Window) {
-	dialog.ShowError(errors.New(errMessage), fw)
 }
 
 type pageConfig struct {

--- a/pkg/imager/widgets/dialogs.go
+++ b/pkg/imager/widgets/dialogs.go
@@ -175,7 +175,7 @@ func ShowCustom(title, dismiss string, content fyne.CanvasObject, parent fyne.Wi
 func ShowError(text string, parent fyne.Window) {
 	label := widget.NewLabelWithStyle(text, fyne.TextAlignLeading, fyne.TextStyle{})
 	label.Wrapping = fyne.TextWrapWord
-	ShowCustom("Error blyat", "Ok", label, parent)
+	ShowCustom("Error", "Ok", label, parent)
 }
 
 // ShowCustomConfirm shows a dialog over the specified application using custom

--- a/pkg/imager/widgets/dialogs.go
+++ b/pkg/imager/widgets/dialogs.go
@@ -19,8 +19,9 @@ import (
 // covers the basic functionality of showing/hiding a window already
 
 const (
-	padWidth  = 32
-	padHeight = 16
+	padWidth    = 32
+	padHeight   = 16
+	dialogWidth = 400
 )
 
 type skydialog struct {
@@ -74,6 +75,9 @@ func (d *skydialog) setButtons(buttons fyne.CanvasObject) {
 	}
 
 	d.win = widget.NewModalPopUp(content, d.parent.Canvas())
+	// fixed width is required to make word-wrapping work correctly
+	// if needed, add new method to set dialog width programmatically, for now it's a constant
+	d.win.Resize(fyne.NewSize(dialogWidth, d.win.MinSize().Height))
 	d.applyTheme()
 }
 
@@ -92,6 +96,10 @@ func (d *skydialog) Layout(obj []fyne.CanvasObject, size fyne.Size) {
 	// content (text)
 	obj[2].Move(fyne.NewPos(size.Width/2-(textMin.Width/2), size.Height-padHeight-btnMin.Height-textMin.Height-theme.Padding()))
 	obj[2].Resize(fyne.NewSize(textMin.Width, textMin.Height))
+	if d.win != nil {
+		obj[2].Move(fyne.NewPos(theme.Padding(), size.Height-padHeight-btnMin.Height-textMin.Height-theme.Padding()))
+		obj[2].Resize(fyne.NewSize(size.Width, size.Height+theme.Padding()))
+	}
 
 	// buttons
 	obj[3].Resize(btnMin)
@@ -159,8 +167,15 @@ func ShowCustom(title, dismiss string, content fyne.CanvasObject, parent fyne.Wi
 		},
 	}
 	d.setButtons(widget.NewHBox(layout.NewSpacer(), d.dismiss, layout.NewSpacer()))
-
 	d.Show()
+}
+
+// ShowError displays an error dialog with a single OK button, that displays given text
+// The text is word wrapped
+func ShowError(text string, parent fyne.Window) {
+	label := widget.NewLabelWithStyle(text, fyne.TextAlignLeading, fyne.TextStyle{})
+	label.Wrapping = fyne.TextWrapWord
+	ShowCustom("Error blyat", "Ok", label, parent)
 }
 
 // ShowCustomConfirm shows a dialog over the specified application using custom


### PR DESCRIPTION
Fixes #64

Changes:
- Wrap lines of error text.

Does this change need to mentioned in CHANGELOG.md?

No

There is no way to specify when the line should be wrapped in characters, and label widget relies on parent width, so error dialogs now have fixed width. 

