### PR TITLE
Pass skybian build version to image

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -18,10 +18,10 @@ ROOT=$(pwd)
 # Armbian latest image dynamic link is https://dl.armbian.com/orangepiprime/Debian_stretch_next.7z
 # URL for the most recent version of this: https://dl.armbian.com/orangepiprime/archive/
 
-ARMBIAN_DOWNLOAD_URL="https://armbian.systemonachip.net/dl/orangepiprime/archive/Armbian_21.02.3_Orangepiprime_buster_current_5.10.21.img.xz"
-ARMBIAN_DOWNLOAD_URL_OPI3="https://armbian.systemonachip.net/dl/orangepi3/archive/Armbian_21.02.3_Orangepi3_buster_current_5.10.21.img.xz"
-RASPBIAN_ARMHF_DOWNLOAD_URL="https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-01-12/2021-01-11-raspios-buster-armhf-lite.zip"
-RASPBIAN_ARM64_DOWNLOAD_URL="https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2020-08-24/2020-08-20-raspios-buster-arm64-lite.zip"
+ARMBIAN_DOWNLOAD_URL="https://armbian.systemonachip.net/dl/orangepiprime/archive/Armbian_21.05.1_Orangepiprime_buster_current_5.10.34.img.xz"
+ARMBIAN_DOWNLOAD_URL_OPI3="https://armbian.systemonachip.net/dl/orangepi3/archive/Armbian_21.05.1_Orangepi3_buster_current_5.10.34.img.xz"
+RASPBIAN_ARMHF_DOWNLOAD_URL="https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-05-28/2021-05-07-raspios-buster-armhf-lite.zip"
+RASPBIAN_ARM64_DOWNLOAD_URL="https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2021-05-28/2021-05-07-raspios-buster-arm64-lite.zip"
 
 # Skywire release download for OS running on destination skyminer
 SKYWIRE_VERSION=v0.4.1

--- a/build.sh
+++ b/build.sh
@@ -478,6 +478,10 @@ copy_to_img()
 
   # Copy systemd units
   info "Copying systemd unit services..."
+
+ # Set Skybian Version on skywire-visor.service
+  sed -i "9i\Environment=SKYBIAN_BUILD_VERSION=${VERSION}" "${ROOT}"/static/skywire-visor.service
+
   local SYSTEMD_DIR=${FS_MNT_POINT}/etc/systemd/system/
   sudo cp -f "${ROOT}"/static/*.service "${SYSTEMD_DIR}" || return 1
 


### PR DESCRIPTION
add skybian build version to skywire-visor service for use in debugging and skywire-visor summary API

Fixes #99 

Changes:  
- added skybian version to `skywire-visor.service` for using in skywire-visor API and debugging.

Does this change need to mentioned in CHANGELOG.md?
No

